### PR TITLE
Add Codespaces devcontainer for GitHub Pages testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "GitHub Pages Dev",
+  "image": "mcr.microsoft.com/devcontainers/jekyll:2.0",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "forwardPorts": [4000],
+  "portsAttributes": {
+    "4000": {
+      "label": "Jekyll server",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "postCreateCommand": "bundle install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "streetsidesoftware.code-spell-checker"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # DataStructures2026
+
+This repository contains materials and configurations for the DataStructures2026 course.
+
+## Codespaces Dev Container
+
+The repository includes a [dev container](.devcontainer/devcontainer.json) configured for testing the GitHub Pages site using Jekyll.
+
+### Troubleshooting
+
+The dev container uses an image where Jekyll should already be installed. If you encounter issues in GitHub Codespaces:
+
+- **`gem install jekyll bundler` returns `403 Forbidden`** – This indicates the container cannot reach RubyGems. Check your network connection or try again later. The bundled image should already have the required gems.
+- **`jekyll: command not found`** – Jekyll is missing from the image. Run `gem install jekyll bundler` or `bundle install` inside the container to install it manually.
+
+After addressing these issues, run `jekyll build` to generate the site.
+


### PR DESCRIPTION
## Summary
- add `.devcontainer` config using Jekyll image and GitHub CLI feature
- document Codespaces troubleshooting tips in `README`

## Testing
- `gem install jekyll bundler` *(fails: 403 "Forbidden")*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b372c4a088327bd9af2550027f431