### PR TITLE
Remove legacy MathJax config from vectors page

### DIFF
--- a/docs/vecs_and_mats.md
+++ b/docs/vecs_and_mats.md
@@ -1,18 +1,3 @@
-    <script type="text/javascript" async
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
-    </script>
-
-    <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-        tex2jax: {
-          inlineMath: [['$','$'], ['\\(','\\)']],
-          displayMath: [['$$','$$'], ['\\[','\\]']],
-          processEscapes: true
-        }
-      });
-    </script>
-    
-
 # 📘 מבוא לוקטורים ומטריצות
 
 ## 🎯 מטרות הלמידה


### PR DESCRIPTION
## Summary
- remove the page-specific MathJax v2 script loader and configuration from `docs/vecs_and_mats.md`
- rely on the shared MathJax 3 configuration included in `docs/_includes/head.html`

## Testing
- not run (Jekyll tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1905dc154832786a99c6bcab9c6b1